### PR TITLE
Issue 9: Allow using 'CodigoProducto' column in `products_file`.

### DIFF
--- a/libresense/R/run_panel.R
+++ b/libresense/R/run_panel.R
@@ -1,6 +1,8 @@
 #' Sensory Board Panel
 #'
 #' @param products_file A character path to the csv file containing the products to evaluate.
+#'   The first column of the file must be the products names. It can have a second column named
+#'   "CodigoProducto" for being shown to the panel, see `product_name` parameter.
 #' @param attributes_file A character path to the csv file containing the attributes to evaluate.
 #' @param design_file A character path to the csv file containing the experimental design.
 #' @param answers_dir A character path to the folder in which to save user responses (if it does not
@@ -74,12 +76,17 @@ run_panel <- function(products_file, attributes_file, design_file = NULL, answer
   if (!"NombreProducto" %in% colnames(design)) {
     design <- mutate(design, NombreProducto = products[Muestra, 1, drop = TRUE])
   }
+  # Prioritize CodigoProducto from design, then from products, then create values if not present.
   if (!"CodigoProducto" %in% colnames(design)) {
-    samples_code <- tibble(
-      Muestra = unique(design$Muestra),
-      CodigoProducto = paste0("P", sample(1000, nrow(products)) - 1)
-    )
-    design <- left_join(design, samples_code, by = "Muestra")
+    if ("CodigoProducto" %in% colnames(products)) {
+      design <- mutate(design, CodigoProducto = products[Muestra, "CodigoProducto", drop = TRUE])
+    } else {
+      samples_code <- tibble(
+        Muestra = unique(design$Muestra),
+        CodigoProducto = paste0("P", sample(1000, nrow(products)) - 1)
+      )
+      design <- left_join(design, samples_code, by = "Muestra")
+    }
   }
   if (!"CodigoMuestra" %in% colnames(design)) {
     design <- mutate(design, CodigoMuestra = paste0("M", sample(1000, nrow(design)) - 1))

--- a/libresense/man/run_panel.Rd
+++ b/libresense/man/run_panel.Rd
@@ -17,7 +17,9 @@ run_panel(
 )
 }
 \arguments{
-\item{products_file}{A character path to the csv file containing the products to evaluate.}
+\item{products_file}{A character path to the csv file containing the products to evaluate.
+The first column of the file must be the products names. It can have a second column named
+"CodigoProducto" for being shown to the panel, see `product_name` parameter.}
 
 \item{attributes_file}{A character path to the csv file containing the attributes to evaluate.}
 


### PR DESCRIPTION
If the `products_file` has a `"CodigoProducto"` column as in:
```r
> read.csv("productos.csv")
      Copa CodigoProducto
1 Herencia              H
2      Uno              U
3  Eredita              E
4    Nieto              N
```
and the panel is run as:
```r
libresense::run_panel(
    products_file = "productos.csv",
    attributes_file = "atributos.csv",
    answers_dir = "Answers/", 
    product_name = "CodigoProducto"
)
```
then the panelists will see the CodigoProducto. And on the board it will be shown the products name.

Note: If using this `prooducts_file` together with a `design_file`, the value `CodigoProducto` will have precedence from the `design_file`.